### PR TITLE
feat(app): switch to T+15 with 5-min cadence (v3)

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -2,8 +2,8 @@ name: velib-ingest
 
 on:
   schedule:
-    # Quarts d’heure précis en UTC → 01,16,31,46
-    - cron: "1,16,31,46 * * * *"
+    # Toutes les 5 minutes en UTC, décalées +1 min pour laisser le temps à la source de publier
+    - cron: "1-59/5 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -38,7 +38,7 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: python -m src.ingest
 
-      - name: Aggregate 15min + weather → docs/exports/
+      - name: Aggregate 5min + weather → docs/exports/
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: python -m src.aggregate
@@ -101,7 +101,7 @@ jobs:
 
           cd hf-ds
           git add -A
-          git commit -m "Update velib exports from ingest (15min)" || echo "Nothing to commit"
+          git commit -m "Update velib exports from ingest (5min)" || echo "Nothing to commit"
 
           # --- inject token dans le remote pour le push https ---
           HF_USER="${HF_DATASET%%/*}"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           python tools/build_monitoring.py \
             --tz Europe/Paris \
-            --horizon 60 \
+            --horizon 15 \
             --last-days 14 \
             --current-days 7 \
             --reference-days 28
@@ -139,11 +139,11 @@ jobs:
           cp -v hf-ds/exports/velib.csv     docs/exports/velib.csv     || true
           ls -lh docs/exports || true
 
-      - name: Retrain LightGBM (T+60)
+      - name: Retrain LightGBM (T+15)
         run: |
           python - << 'PY'
           from src.forecast import train
-          res = train(horizon_minutes=60, lookback_days=30)
+          res = train(horizon_minutes=15, lookback_days=30)
           print(res)
           import json, pathlib
           p = pathlib.Path("docs/exports"); p.mkdir(parents=True, exist_ok=True)
@@ -170,7 +170,7 @@ jobs:
         run: |
           python tools/build_monitoring.py \
             --tz Europe/Paris \
-            --horizon 60 \
+            --horizon 15 \
             --last-days 14 \
             --current-days 7 \
             --reference-days 28

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -91,7 +91,7 @@ jobs:
           print("[train] timespan:", df['tbin_utc'].min(), "->", df['tbin_utc'].max())
           PY
 
-      - name: Train LGBM (T+60) and verify model file
+      - name: Train LGBM (T+15) and verify model file
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
@@ -99,7 +99,7 @@ jobs:
           set -euxo pipefail
           python - <<'PY'
           from src.forecast import train
-          out = train(horizon_minutes=60, lookback_days=30)
+          out = train(horizon_minutes=15, lookback_days=30)
           print("[train] OUT:", out)
           PY
 
@@ -107,13 +107,13 @@ jobs:
           ls -lah models || true
 
           echo "=== Check model presence ==="
-          test -f models/lgb_nbvelos_T+60min.joblib || { echo "[CI] modèle introuvable après entraînement"; exit 1; }
+          test -f models/lgb_nbvelos_T+15min.joblib || { echo "[CI] modèle introuvable après entraînement"; exit 1; }
 
       - name: Upload model bundle (artifact)
         uses: actions/upload-artifact@v4
         with:
-          name: model-lgbm-T+60min
-          path: models/lgb_nbvelos_T+60min.joblib
+          name: model-lgbm-T+15min
+          path: models/lgb_nbvelos_T+15min.joblib
           retention-days: 14
 
       - name: Commit model into repo
@@ -122,10 +122,10 @@ jobs:
           set -euxo pipefail
           git config user.name  "github-actions"
           git config user.email "actions@users.noreply.github.com"
-          git add -f models/lgb_nbvelos_T+60min.joblib
+          git add -f models/lgb_nbvelos_T+15min.joblib
           if git diff --cached --quiet; then
             echo "No model change to commit."
           else
-            git commit -m "ci(train): update model lgb_nbvelos_T+60min.joblib"
+            git commit -m "ci(train): update model lgb_nbvelos_T+15min.joblib"
             git push
           fi

--- a/README.md
+++ b/README.md
@@ -1,53 +1,38 @@
-# 🚲 Vélib’ Paris — Forecast & Monitoring
+# 🚲 Vélib’ Paris — Forecast & Monitoring (v3)
+
 [![CI — ingestion](https://github.com/Adrien-1997/bike-forecast-paris-velib/actions/workflows/ingest.yml/badge.svg)](https://github.com/Adrien-1997/bike-forecast-paris-velib/actions/workflows/ingest.yml)
 [![CI — training](https://github.com/Adrien-1997/bike-forecast-paris-velib/actions/workflows/train.yml/badge.svg)](https://github.com/Adrien-1997/bike-forecast-paris-velib/actions/workflows/train.yml)
 [![Docs](https://github.com/Adrien-1997/bike-forecast-paris-velib/actions/workflows/site.yml/badge.svg?branch=main)](https://adrien-1997.github.io/bike-forecast-paris-velib/)
-[![App Streamlit](https://img.shields.io/badge/app-streamlit-green)](https://adrien-1997-bike-forecast-paris-velib-appstreamlit-app-vq1xma.streamlit.app/)
-![Version](https://img.shields.io/badge/version-v2.3.0-red.svg)
+[![App Streamlit](https://img.shields.io/badge/app-streamlit-green)](https://velib-forecast.streamlit.app/)
+![Version](https://img.shields.io/badge/version-v3.0.0-blue.svg)
 ![License](https://img.shields.io/badge/License-MIT-black)
 ![Python](https://img.shields.io/badge/Python-3.11+-3776AB)
 
 ![Carte réseau](docs/map.png)
 
-Short-term forecasting (+60 min) and professional monitoring of the Vélib’ bike network in Paris.
-Public GBFS snapshots -> normalized 15-min aggregates -> features & model training -> monitoring with auto-retrain.
+Short‑term forecasting (**T+15 min**) and professional monitoring of the Vélib’ bike network in Paris.  
+Public GBFS snapshots → normalized **5‑min** aggregates → features & model training → monitoring with auto‑retrain.
 
-> Quick links:
-> Docs -> https://adrien-1997.github.io/bike-forecast-paris-velib/
-> App  -> https://velib-forecast.streamlit.app/
-
----
-
-## Table of Contents
-
-- [Key Features](#-key-features)
-- [Pipelines — Data → ML → Docs & App](#-pipelines--data--ml--docs--app)
-- [CI/CD (GitHub Actions)](#-cicd-github-actions)
-- [Run locally](#-run-locally)
-- [Streamlit App](#-app-streamlit)
-- [Data Contracts (canonical schemas)](#-data-contracts-canonical-schemas)
-- [Project Layout](#-project-layout)
-- [Release Notes — v2.2.0](#-release-notes--v210)
-- [Author & License](#-author--license)
+> Quick links:  
+> Docs → https://adrien-1997.github.io/bike-forecast-paris-velib/  
+> App  → https://velib-forecast.streamlit.app/
 
 ---
 
 ## 🔎 Key Features
 
-## Key Features
+- **15‑min forecasting (T+15)**  
+  LightGBM predicts bike availability 15 minutes ahead with strict feature parity (lags/rollings + calendar/weather).
 
-- **60-min forecasting (T+60)**  
-  LightGBM predicts bike availability 60 minutes ahead with strict feature parity (lags/rollings + calendar features).
-
-- **Robust data pipeline**  
-  Ingestion every **15 min** → DuckDB snapshots → 15-min aggregation + weather join → canonical `docs/exports/velib.parquet`.
+- **Robust data pipeline (5‑min cadence)**  
+  Ingestion every **5 min** → DuckDB snapshots → **5‑min** canonical export with weather join (right‑closed grid).
 
 - **Clean targets & alignment**  
-  `y_true = bikes@T+60` (shift), baseline = persistence@T, predictions aligned on **T** to avoid leakage.
+  `y_true = bikes@T+15` (per station via shift), baseline = persistence@T, predictions aligned on **T** and evaluated at **T+15**.
 
 - **Hugging Face integration**  
-  - **Datasets**: parquet exports pushed to HF Datasets.  
-  - **Models**: `.joblib` bundles (model + feature contract + horizon) pushed to HF Model Hub.
+  - **Datasets**: parquet exports on HF Datasets.  
+  - **Models**: `.joblib` bundles (model + feature contract + horizon=15) on HF Model Hub.
 
 - **Monitoring & quality**  
   - **Data health**: freshness, completeness, schema checks.  
@@ -59,21 +44,10 @@ Public GBFS snapshots -> normalized 15-min aggregates -> features & model traini
   - **Data**: Exports, Dictionary, Methodology.  
   - **Monitoring**: Data health, Drift, Model health.  
   - **Model**: Pipeline, Performance, Explainability.  
-  - **Network**: Overview, Stations, Dynamics.
-
-- **CI/CD**  
-  1. `velib-ingest` (15 min) → update parquet + push HF dataset.  
-  2. `velib-train` (daily or triggered) → export models to HF.  
-  3. `monitoring-site` (4×/day) → build pages, run drift/perf checks, deploy **gh-pages**.
+  - **Network**: Overview, Stations, Dynamics (profiles computed on **15‑min** quarters; live KPIs on **5‑min** cadence).
 
 - **Streamlit app**  
-  Interactive map, real-time availability/saturation, **T+60** forecasts, reads model bundle + parquet.
-
-- **Analytics & insights**  
-  Station clustering, heatmaps, variability, daily/hourly profiles, residual analysis & calibration.
-
-
-> All figures and tables displayed on the online site are generated from the canonical dataset (`velib.parquet`), available on Hugging Face Datasets.
+  Interactive map, real‑time availability/saturation, **T+15** forecasts.
 
 ---
 
@@ -82,62 +56,59 @@ Public GBFS snapshots -> normalized 15-min aggregates -> features & model traini
 ```mermaid
 flowchart TD
 
-  %% SOURCES & AGRÉGAT
+  %% SOURCES & AGG
   subgraph Sources
-    GBFS[GBFS snapshots];
+    GBFS[GBFS snapshots (5m)];
     WX[Weather hourly];
   end
 
-  GBFS --> AGG[Aggregate + weather join];
+  GBFS --> AGG[Aggregate (5m) + weather join];
   WX   --> AGG;
-  AGG  --> VELIB[velib_parquet];
+  AGG  --> VELIB[docs/exports/velib.parquet];
 
   %% NORMALISATION
   VELIB --> NORM[Normalize datasets];
-  NORM  --> EV[events_parquet];
-  NORM  --> PF[perf_parquet];
+  NORM  --> EV[events.parquet (5m)];
+  NORM  --> PF[perf.parquet (T & T+15 align)];
 
-  %% PIPELINE MODELE
+  %% MODEL PIPELINE
   CAL[Calendar features];
   VELIB --> FEAT[Build features];
   CAL   --> FEAT;
   FEAT  --> TRAIN[Train LGBM T+15];
-  TRAIN --> MODEL[Model bundle joblib];
+  TRAIN --> MODEL[Model bundle (.joblib, horizon=15)];
 
-  %% APPLICATION MODELE
-  MODEL --> APPLY[Apply model y_pred];
+  %% PREDICTION
+  MODEL --> APPLY[Apply model → y_pred];
   EV    --> APPLY;
   PF    --> APPLY;
 
-  %% PAGES / RAPPORTS (simplifiés)
+  %% PAGES
   subgraph Pages
     P1[Data pages];
     P2[Monitoring pages];
     P3[Model pages];
     P4[Network pages];
   end
-
   EV    --> P4;
   EV    --> P1;
   PF    --> P2;
   PF    --> P3;
-  VELIB --> P1;
 
   %% HUGGING FACE HUB
-  subgraph HuggingFace
+  subgraph HF[Hugging Face]
     HFDS[Datasets];
     HFM[Models];
   end
-
   VELIB --> HFDS;
   MODEL --> HFM;
 
-  %% ORCHESTRATIONS CI/CD
-  subgraph CI_CD
-    CI1[ingest every 15m];
+  %% CI/CD
+  subgraph CI[CI/CD]
+    CI1[ingest every 5m];
     CI3[site build 4x/day];
-    CI2[train daily];
-    CHECK[check_retrain];
+    CI2[train daily or on-trigger];
+    CHECK[check_retrain (MAE/PSI)];
   end
 
   CI1 --> GBFS;
@@ -153,58 +124,41 @@ flowchart TD
   CHECK --> CI2;
   CI2 --> TRAIN;
   CI2 --> HFM;
-
-  %% APP
-  APP[Streamlit app] --> AGG;
 ```
 
-### Core src/* chain
+### Core `src/*` chain (v3)
 
-1) Ingestion — `src/ingest.py` (every 15 min)  
+1) **Ingestion — `src/ingest.py` (every 5 min)**  
    Pull GBFS, normalize, upsert station meta, append one row/station in snapshots.
 
-2) Aggregation — `src/aggregate.py` (15-min + weather)  
-   Right-closed 15-min grid; `occ = bikes/capacity` (safe clamp); join weather; write `docs/exports/velib.parquet`.
+2) **Aggregation — `src/aggregate.py` (5‑min + weather)**  
+   Right‑closed **5‑min** grid; `occ = bikes/capacity` (safe clamp); weather join; write `docs/exports/velib.parquet`.
 
-3) Feature builder — `src/features.py`  
-   Hour/DOW cyclics, lags (t-15/30/45/60), rolling mean/std, static station, weather. (horizon=60)
+3) **Feature builder — `src/features.py` (horizon=15)**  
+   Calendar cyclics, lags (t‑5/10/15), rollings, static station, weather.
 
-4) Forecast — `src/forecast.py`  
-   LightGBM with early-stopping; saves `models/*.joblib` and `docs/exports/baseline.json`.
+4) **Forecast — `src/forecast.py`**  
+   LightGBM with early‑stopping; saves `models/*.joblib` and `docs/exports/baseline.json` (baseline=Persistence@T).
 
 ---
 
-### 🤖 CI/CD (GitHub Actions)
+## 🤖 CI/CD (GitHub Actions)
 
-This pipeline keeps data and docs fresh while guarding model quality:
-
-- **Ingestion (`velib-ingest.yml`, every 15 min):** fetch GBFS → update DuckDB snapshots → aggregate to 15‑min bins → export `docs/exports/velib.parquet`.
-- **Docs & monitoring (`site.yml`, 4×/day @ 00/06/12/18 UTC):** build MkDocs, compute metrics, check **drift/perf** (PSI / MAE_24h). If thresholds are exceeded, it triggers retraining.
-- **Training (`train.yml`, daily fallback or immediate):** train LightGBM T+60, write `models/*.joblib` and `docs/exports/baseline.json`, then rebuild docs.
+- **Ingestion (`ingest.yml`, every 5 min):** fetch GBFS → update DuckDB snapshots → aggregate to **5‑min** bins → export `docs/exports/velib.parquet`.
+- **Docs & monitoring (`site.yml`, 4×/day @ 00/06/12/18 UTC):** build MkDocs, compute metrics, check **drift/perf** (PSI / MAE). If thresholds are exceeded, it triggers retraining.
+- **Training (`train.yml`, daily or on‑demand):** train LightGBM **T+15**, write `models/*.joblib` and `docs/exports/baseline.json`, then rebuild docs.
 
 ```mermaid
 flowchart LR
   subgraph CI[CI/CD]
-    I[velib-ingest.yml\nEvery 15 min] -->|exports| D[docs/exports/velib.parquet]
-    S[site.yml\n4x/day] -->|builds| M[Docs -> gh-pages]
-    S -->|checks| T[check_retrain\nPSI or MAE_24h]
+    I[ingest.yml — 5m] -->|exports| D[docs/exports/velib.parquet]
+    S[site.yml — 4x/day] -->|builds| M[Docs → gh-pages]
+    S -->|checks| T[check_retrain (PSI or MAE lift)]
     T -->|yes| R[train.yml]
     R -->|models + baseline| J[models/*.joblib + baseline.json]
     R -->|rebuild| M
   end
 ```
-
-#### Jobs at a glance
-
-| Job | What it does | Deps |
-|---|---|---|
-| **build-monitor** (`site.yml`) | Install `requirements-doc.txt` (headless `MPLBACKEND=Agg`), run `tools/generate_monitoring.py`, decide retrain via `tools/check_retrain.py` (**PSI ≥ 0.20** or **MAE_24h ≥ 1.20× baseline**), build & deploy MkDocs to `gh-pages`. | pandas, numpy, pyarrow, matplotlib, scikit-learn, folium, mkdocs |
-| **retrain-and-rebuild** (`train.yml`, conditional) | Install `requirements-train.txt` (scikit-learn + lightgbm), run `src.forecast.train(horizon_minutes=60, lookback_days=30)`, save `models/*.joblib` and `docs/exports/baseline.json`, **force-add** ignored paths, re‑generate monitoring, rebuild docs, deploy. | scikit-learn, lightgbm |
-
-**Operational notes**  
-- `tools/check_retrain.py` supports legacy `docs/exports/metrics.json` **and** the new CSV/Parquet tables.  
-- The commit step **force‑adds** `baseline.json` (and models if you choose) even if `.gitignore` ignores `docs/exports` / `models`.  
-- Cache `~/.cache/pip` to speed up both jobs.
 
 ---
 
@@ -215,13 +169,14 @@ flowchart LR
 pip install -r requirements-doc.txt
 
 # 2) Build all figures/pages from canonical parquet
-python tools/generate_monitoring.py
+python tools/build_monitoring.py
 
 # 3) Serve docs locally
 mkdocs serve
 ```
 
-**Use a trained model?** Merge predictions into `docs/exports/perf.parquet` (`ts, station_id, y_pred`) then re‑run monitoring.
+**Use a trained model?**  
+Merge predictions into `docs/exports/perf.parquet` (`ts, station_id, y_pred`) then re‑run monitoring.
 
 ---
 
@@ -236,18 +191,19 @@ streamlit run app/streamlit_app.py
 
 ---
 
-## 📐 Data Contracts (canonical schemas)
+## 📐 Data Contracts (canonical schemas, v3)
 
-**A) `warehouse.duckdb::snapshots` (append‑only)**  
-`ts, station_id, bikes, capacity, docks_free, is_renting, is_returning, is_installed, name, lat, lon[, ebikes]`  
-Index hint: clustered by `(ts, station_id)`.
+**A) `warehouse.duckdb::snapshots` (append‑only, 5m)**  
+`ts, station_id, bikes, capacity, docks_free, is_renting, is_returning, is_installed, name, lat, lon[, ebikes]`
 
-**B) `docs/exports/velib.parquet` (15‑min canonical)**  
+**B) `docs/exports/velib.parquet` (5‑min canonical)**  
 `ts(UTC), station_id, bikes, capacity, occ, lat, lon, name, temp_c, rain_mm, wind_kph, dow, hour`
 
 **C) Training exports (`tools/datasets.py`)**  
-- `events.parquet` → `ts, station_id, bikes, capacity, occ, lat, lon, name`  
-- `perf.parquet` → `ts, station_id, y_true, y_pred[, y_pred_baseline]` (rebuild `y_true` via **T+60** shift if missing)
+- `events.parquet` → **5‑min** `ts, station_id, bikes, capacity, occ, lat, lon, name`  
+- `perf.parquet`   → `ts, station_id, y_true, y_pred[, y_pred_baseline], horizon_min=15, ts_decision=T, ts_target=T+15`
+
+> Note: Network analytics pages still display **24h profiles on 15‑min quarters (96 bins)** for stability and readability, while live KPIs operate at **5‑min cadence**.
 
 ---
 
@@ -255,47 +211,29 @@ Index hint: clustered by `(ts, station_id)`.
 
 ```
 bike-forecast-paris-velib/
-├─ app/ # Streamlit app
-├─ src/ # ingestion, aggregation, features, forecast
-│ ├─ ingest.py
-│ ├─ aggregate.py
-│ ├─ features.py
-│ └─ forecast.py
-├─ tools/
-│ ├─ datasets.py
-│ ├─ apply_model.py
-│ ├─ build_*.py
-│ └─ check_retrain.py
-├─ docs/
-│ ├─ assets/{figs,tables,maps}
-│ ├─ exports/
-│ └─ {network,model,monitoring,data}/
-├─ models/
-├─ .github/workflows/{ingest.yml,train.yml,site.yml}
-└─ mkdocs.yml
+├─ app/                       # Streamlit app
+├─ src/                       # ingestion, aggregation, features, forecast
+├─ tools/                     # build scripts (pages, datasets, checks)
+├─ docs/                      # assets, exports, site
+├─ models/                    # trained bundles
+└─ .github/workflows/         # ingest.yml, train.yml, site.yml
 ```
+
 ---
 
+## Release Notes — v3.0.0
 
-## Release Notes — v2.3.0
-
-**MkDocs revamp (site overhaul)**
-- Clear 4×3 structure: **Network**, **Model**, **Monitoring**, **Data**.
-- *One script = one page*: dedicated `tools/build_*` generators with KPI injection into Markdown.
-- Maps & charts: Folium map **with legend**, “Today vs Median” curve, daily KPIs vs **D-7/D-14/D-21**.
-- Robust relative paths (`use_directory_urls: true`) and auto-created `docs/assets/{figs,tables,maps}`.
-- Windows-friendly: ASCII logs, UTF-8 (no BOM).
-- **Backed by Hugging Face**: the canonical dataset (`velib.parquet`) is stored on **Hugging Face Datasets**; pages are built from that source and published on GitHub Pages.
-
-**Model & data**
-- `apply_model.py`: correct **T+h → T** alignment, stable station mapping.
-- `datasets.py`: cleaner output; safer types/encoding.
+- **Cadence 5 min** end‑to‑end (ingestion → canonical parquet).  
+- **Horizon T+15**: training & evaluation; `ts_decision` / `ts_target` added to `perf.parquet`.  
+- **Docs refresh**: wording and figures updated to reflect 5‑min cadence; profiles remain quarter‑hour for readability.  
+- **Tooling**: `check_retrain.py` thresholds documented; robust plots & Folium legends.
+- **Safety**: deterministic KMeans (random_state=42), consistent relative paths for MkDocs.
 
 ---
 
 ## 👤 Author & License
 
 **Adrien Morel** — Data Scientist (applied math & ML)  
-Docs: [https://adrien-1997.github.io/bike-forecast-paris-velib/](https://adrien-1997.github.io/bike-forecast-paris-velib/) • App: [https://adrien-1997-bike-forecast-paris-velib-appstreamlit-app-vq1xma.streamlit.app/](https://velib-forecast.streamlit.app/)
+Docs: https://adrien-1997.github.io/bike-forecast-paris-velib/ • App: https://velib-forecast.streamlit.app/
 
 **License:** MIT

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-﻿site_name: "Vélib’ Paris — Forecast (Batch)"
+﻿site_name: "Vélib’ Paris — Forecast +15min (Batch)"
 site_url: "https://adrien-1997.github.io/bike-forecast-paris-velib/"
 repo_url: "https://github.com/Adrien-1997/bike-forecast-paris-velib"
 repo_name: "Adrien-1997/bike-forecast-paris-velib"

--- a/src/cal_features.py
+++ b/src/cal_features.py
@@ -12,13 +12,20 @@ except Exception:
 
 def add_calendar_features(df: pd.DataFrame, tz: str = "Europe/Paris") -> pd.DataFrame:
     """
-    Ajoute: hour, dow, is_weekend, is_rush_am, is_rush_pm, is_holiday,
-            hour_sin, hour_cos.
-    Utilise la colonne 'hour_utc' (UTC naïf) déjà présente dans l'agrégat.
+    Ajoute (UTC→locale):
+      - hour, dow, is_weekend, is_rush_am, is_rush_pm, is_holiday
+      - hour_sin, hour_cos  (cycle 24h)
+      - minute, min5_idx (0..11), minute_sin, minute_cos (cycle 60 min)
+      - tod_sin, tod_cos (cycle 24h en minutes, plus fin que hour_sin/cos)
+
+    Hypothèses:
+      - df contient 'hour_utc' (UTC naïf, floored à l'heure).
+      - Si présent, 'tbin_utc' (UTC naïf au pas 5 min) sert à dériver la minute locale;
+        sinon, minute=0 par construction (fallback sûr).
     """
     out = df.copy()
 
-    # hour_utc -> tz locale
+    # Base horaire à partir de hour_utc (aware→locale)
     ts_utc = pd.to_datetime(out["hour_utc"], errors="coerce", utc=True)
     ts_loc = ts_utc.dt.tz_convert(tz)
 
@@ -28,6 +35,7 @@ def add_calendar_features(df: pd.DataFrame, tz: str = "Europe/Paris") -> pd.Data
     out["is_rush_am"] = ts_loc.dt.hour.between(7, 9).astype("int8")
     out["is_rush_pm"] = ts_loc.dt.hour.between(17, 19).astype("int8")
 
+    # Jours fériés (par date locale)
     dates = ts_loc.dt.date
     if isinstance(FR_HOL, set):
         out["is_holiday"] = np.fromiter((1 if d in FR_HOL else 0 for d in dates),
@@ -36,16 +44,44 @@ def add_calendar_features(df: pd.DataFrame, tz: str = "Europe/Paris") -> pd.Data
         out["is_holiday"] = np.fromiter((1 if d in FR_HOL else 0 for d in dates),
                                         count=len(out), dtype=np.int8)
 
-    # Encodage circulaire (vectorisé)
-    angle = 2.0 * np.pi * (out["hour"].to_numpy(dtype=np.float32) / 24.0)
-    out["hour_sin"] = np.sin(angle).astype("float32")
-    out["hour_cos"] = np.cos(angle).astype("float32")
+    # Encodage circulaire horaire (identique à ton implémentation)
+    angle_h = 2.0 * np.pi * (out["hour"].to_numpy(dtype=np.float32) / 24.0)
+    out["hour_sin"] = np.sin(angle_h).astype("float32")
+    out["hour_cos"] = np.cos(angle_h).astype("float32")
+
+    # ------- Nouveaux features intra-heure (pas 5 min) -------
+    # Si 'tbin_utc' existe, on calcule la minute locale exacte; sinon minute=0.
+    if "tbin_utc" in out.columns:
+        tbin_utc = pd.to_datetime(out["tbin_utc"], errors="coerce", utc=True)
+        tbin_loc = tbin_utc.dt.tz_convert(tz)
+        minute = tbin_loc.dt.minute.fillna(0).astype("int16")
+    else:
+        minute = pd.Series(0, index=out.index, dtype="int16")
+
+    out["minute"] = minute
+    # Index 5-min dans l’heure: 0..11 (robuste même si minute≠multiple de 5)
+    out["min5_idx"] = (out["minute"] // 5).astype("int16")
+
+    # Encodage circulaire minute (cycle 60) et "time-of-day" en minutes (cycle 1440)
+    angle_m = 2.0 * np.pi * (out["minute"].to_numpy(dtype=np.float32) / 60.0)
+    out["minute_sin"] = np.sin(angle_m).astype("float32")
+    out["minute_cos"] = np.cos(angle_m).astype("float32")
+
+    tod_minutes = (out["hour"].astype("int32") * 60 + out["minute"].astype("int32")).to_numpy()
+    angle_tod = 2.0 * np.pi * (tod_minutes.astype(np.float32) / 1440.0)
+    out["tod_sin"] = np.sin(angle_tod).astype("float32")
+    out["tod_cos"] = np.cos(angle_tod).astype("float32")
 
     return out
 
 def feature_cols(df: pd.DataFrame) -> list[str]:
-    base = ["hour", "dow", "is_weekend", "is_rush_am", "is_rush_pm", "is_holiday",
-            "hour_sin", "hour_cos"]
+    base = [
+        "hour", "dow", "is_weekend", "is_rush_am", "is_rush_pm", "is_holiday",
+        "hour_sin", "hour_cos",
+        # Intra-heure (5 min)
+        "minute", "min5_idx", "minute_sin", "minute_cos",
+        "tod_sin", "tod_cos",
+    ]
     weather = [c for c in ["temp_C", "precip_mm", "wind_mps"]
                if c in df.columns and not df[c].isna().all()]
     return base + weather

--- a/src/features.py
+++ b/src/features.py
@@ -7,7 +7,11 @@ import numpy as np
 from src.cal_features import add_calendar_features, feature_cols as calfeat_cols
 from src.utils_io import get_export_path
 
-def _load_base_15min() -> pd.DataFrame:
+def _load_base_5min() -> pd.DataFrame:
+    """
+    Charge le parquet agrégé au pas 5 min (docs/exports/velib.parquet via get_export_path)
+    et normalise les timestamps (UTC naïfs).
+    """
     try:
         path = get_export_path("velib.parquet")
         df = pd.read_parquet(path)
@@ -26,48 +30,52 @@ def _load_base_15min() -> pd.DataFrame:
     return df
 
 
-def build_training_frame(horizon_minutes: int = 60, lookback_days: int = 30):
+def build_training_frame(horizon_minutes: int = 15, lookback_days: int = 30):
     """
-    Construit le dataset d'entraînement à partir du parquet 15 min.
-    - Cible: y_nb = nb vélos à +horizon_minutes (ex: 60 → +4 bins)
-    - Lags/rollings/trends basés sur des bins de 15 min
+    Construit le dataset d'entraînement à partir du parquet 5 min.
+    - Cible: y_nb = nb vélos à +horizon_minutes (ex: 15 → +3 bins)
+    - Lags/rollings/trends basés sur des bins de 5 min
     """
-    base = _load_base_15min()
+    if horizon_minutes % 5 != 0 or horizon_minutes < 5:
+        raise ValueError("horizon_minutes must be a multiple of 5 and >= 5.")
+
+    base = _load_base_5min()
 
     # Fenêtre lookback calée sur la donnée (jamais avant tmin)
     tmin = pd.to_datetime(base["tbin_utc"]).min()
     tmax = pd.to_datetime(base["tbin_utc"]).max()
-    binsize = pd.Timedelta(minutes=15)
-    # si lookback_days est petit et que le parquet est ancien, ne coupe pas tout
+    binsize = pd.Timedelta(minutes=5)
     cutoff = max(tmax.floor(binsize) - pd.Timedelta(days=lookback_days), tmin)
     base = base[base["tbin_utc"] >= cutoff].copy()
 
     # Tri
     base = base.sort_values(["stationcode", "tbin_utc"])
 
-    # Cible: +N bins (N = horizon_minutes / 15)
-    bins_h = max(1, int(round(horizon_minutes / 15)))
+    # Cible: +N bins (N = horizon_minutes / 5)
+    bins_h = max(1, int(round(horizon_minutes / 5)))
     base["y_nb"] = base.groupby("stationcode", group_keys=False)["nb_velos_bin"].shift(-bins_h)
 
-    # Exiger un minimum de contexte par station (plus souple)
-    # besoin ≈ horizon + lags max (16) ; mais assoupli pour éviter de tout vider
-    min_rows = max(bins_h + 8, 8)
+    # Exiger un minimum de contexte par station (souple)
+    # besoin ≈ horizon + lags max (~48) ; on reste raisonnable
+    min_rows = max(bins_h + 12, 12)
     vc = base.groupby("stationcode")["tbin_utc"].transform("count")
     base = base[vc >= min_rows].copy()
 
-    # Lags & rollings
+    # Lags & rollings (bins de 5 min): 1,3,6,12,24,48 => 5,15,30,60,120,240 min
     def add_lags_rollings(dfg: pd.DataFrame) -> pd.DataFrame:
         g = dfg.copy()
-        lag_bins = (1, 2, 3, 4, 8, 16)  # 15,30,45,60,120,240 min
+        lag_bins = (1, 3, 6, 12, 24, 48)
         for b in lag_bins:
             g[f"lag_nb_{b}b"]  = g["nb_velos_bin"].shift(b)
             g[f"lag_occ_{b}b"] = g["occ_ratio_bin"].shift(b)
-        g["roll_nb_4b"]  = g["nb_velos_bin"].rolling(4, min_periods=1).mean()
-        g["roll_nb_8b"]  = g["nb_velos_bin"].rolling(8, min_periods=1).mean()
-        g["roll_occ_4b"] = g["occ_ratio_bin"].rolling(4, min_periods=1).mean()
-        g["roll_occ_8b"] = g["occ_ratio_bin"].rolling(8, min_periods=1).mean()
-        g["trend_nb_4b"]  = (g["nb_velos_bin"] - g["nb_velos_bin"].shift(4)) / 4.0
-        g["trend_occ_4b"] = (g["occ_ratio_bin"] - g["occ_ratio_bin"].shift(4)) / 4.0
+        # Moyennes glissantes ~1h et ~2h
+        g["roll_nb_12b"]  = g["nb_velos_bin"].rolling(12, min_periods=1).mean()
+        g["roll_nb_24b"]  = g["nb_velos_bin"].rolling(24, min_periods=1).mean()
+        g["roll_occ_12b"] = g["occ_ratio_bin"].rolling(12, min_periods=1).mean()
+        g["roll_occ_24b"] = g["occ_ratio_bin"].rolling(24, min_periods=1).mean()
+        # Trend ~1h
+        g["trend_nb_12b"]  = (g["nb_velos_bin"] - g["nb_velos_bin"].shift(12)) / 12.0
+        g["trend_occ_12b"] = (g["occ_ratio_bin"] - g["occ_ratio_bin"].shift(12)) / 12.0
         return g
 
     # groupby.apply sans FutureWarning (compat pandas récents)
@@ -80,17 +88,17 @@ def build_training_frame(horizon_minutes: int = 60, lookback_days: int = 30):
             lambda g: add_lags_rollings(g.drop(columns=[], errors="ignore"))
         )
 
-    # Features calendaires (Europe/Paris)
+    # Features calendaires (Europe/Paris) — inclut minute/min5_idx si tbin_utc présent
     base = add_calendar_features(base, tz="Europe/Paris")
 
     # Colonnes numériques
     num_cols = [
         "nb_velos_bin","nb_bornes_bin","capacity_bin","occ_ratio_bin",
         "temp_C","precip_mm","wind_mps",
-        *[f"lag_nb_{b}b" for b in (1,2,3,4,8,16)],
-        *[f"lag_occ_{b}b" for b in (1,2,3,4,8,16)],
-        "roll_nb_4b","roll_nb_8b","roll_occ_4b","roll_occ_8b",
-        "trend_nb_4b","trend_occ_4b",
+        *[f"lag_nb_{b}b" for b in (1,3,6,12,24,48)],
+        *[f"lag_occ_{b}b" for b in (1,3,6,12,24,48)],
+        "roll_nb_12b","roll_nb_24b","roll_occ_12b","roll_occ_24b",
+        "trend_nb_12b","trend_occ_12b",
         *calfeat_cols(base),
     ]
     seen = set(); num_cols = [c for c in num_cols if not (c in seen or seen.add(c))]
@@ -110,14 +118,13 @@ def build_training_frame(horizon_minutes: int = 60, lookback_days: int = 30):
     base = base.dropna(subset=["y_nb"]).reset_index(drop=True)
     base["y_nb"] = base["y_nb"].astype("float32")
 
-    # Si malgré tout c'est vide, tenter un fallback "tout le parquet"
+    # Fallback si vide: rejouer sur tout le parquet
     if base.empty:
-        base_all = _load_base_15min().sort_values(["stationcode","tbin_utc"]).copy()
+        base_all = _load_base_5min().sort_values(["stationcode","tbin_utc"]).copy()
         base_all["y_nb"] = base_all.groupby("stationcode", group_keys=False)["nb_velos_bin"].shift(-bins_h)
         vc = base_all.groupby("stationcode")["tbin_utc"].transform("count")
         base_all = base_all[vc >= min_rows].dropna(subset=["y_nb"])
         if not base_all.empty:
-            # Rejouer lags/rollings + cal features rapidement
             base_all = base_all.groupby("stationcode", group_keys=False, as_index=False).apply(
                 lambda g: add_lags_rollings(g.drop(columns=[], errors="ignore"))
             )

--- a/tools/build_monitoring.py
+++ b/tools/build_monitoring.py
@@ -9,7 +9,7 @@
 #     - tools/build_network_stations.py
 #     - tools/build_network_dynamics.py
 #   Model
-#     - tools/build_model_performance.py        (or reuse existing build_performance.py)
+#     - tools/build_model_performance.py
 #     - tools/build_model_pipeline.py
 #     - tools/build_model_explainability.py
 #   Monitoring
@@ -62,7 +62,7 @@ def run(cmd: List[object]) -> None:
         cmd,
         capture_output=True,
         text=True,
-        encoding="utf-8",     # ← au lieu de cp1252
+        encoding="utf-8",     # robust logs on all platforms
         errors="replace"
     )
     if res.stdout:
@@ -81,7 +81,7 @@ def run_optional(cmd: List[object]) -> None:
         cmd,
         capture_output=True,
         text=True,
-        encoding="utf-8",     # ← idem ici
+        encoding="utf-8",
         errors="replace"
     )
     if res.stdout:
@@ -131,7 +131,7 @@ def main():
     ap.add_argument("--out-perf", type=Path, default=PERF)
 
     # Global params
-    ap.add_argument("--horizon", type=int, default=60, help="Forecasting horizon in minutes.")
+    ap.add_argument("--horizon", type=int, default=15, help="Forecasting horizon in minutes.")
     ap.add_argument("--lookback-days", type=int, default=14, help="History window for feature building (apply_model).")
     ap.add_argument("--last-days", type=int, default=7, help="Analysis window for most pages (days).")
     ap.add_argument("--current-days", type=int, default=7, help="Current window (drift/health).")
@@ -247,14 +247,15 @@ def main():
             "--events", args.out_events,
             "--current-days", str(args.current_days),
             "--reference-days", str(args.reference_days),
-            "--perf", args.out_perf,                 # ← ajouter
+            "--perf", args.out_perf,
+            "--bin-min", "5",                       # IMPORTANT: events at 5-minute cadence
             *(["--tz", args.tz] if args.tz else []),
         ],
         "monitoring.model_health": lambda: [
             sys.executable, TOOLS / "build_monitoring_model_health.py",
             "--perf", args.out_perf,
             "--last-days", str(args.last_days),
-            "--horizon", str(args.horizon),          # ← ajouter
+            "--horizon", str(args.horizon),
             *(["--tz", args.tz] if args.tz else []),
         ],
         # --- Data ---
@@ -271,7 +272,6 @@ def main():
             sys.executable, TOOLS / "build_data_methodology.py",
             "--events", args.out_events,
             "--perf", args.out_perf,
-            # "--horizon", str(args.horizon),      # ← retirer si non utilisé
         ],
     }
 


### PR DESCRIPTION
UI/labels: “Forecast T+15” across map, popups, monitoring

Auto-refresh parquet if > 5 min (was 15)

Live features aligned to 5-min bins

lags: 1/2/3/6/12 bins (5/10/15/30/60 min)

rollings: 3b/6b; trends: 3b

Predictor: load_model_bundle(horizon_minutes=15) + predict_nbvelos_t15

Weather badges & parquet freshness preserved and hardened

More robust HF parquet resolution (force/refresh, cache buster)

BREAKING CHANGE: default horizon changes from T+60 to T+15 in the app.